### PR TITLE
feat(backend): Implement /snippets POST and GET endpoints

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -22,5 +22,12 @@ def create_snippet():
     return jsonify({'id': snippet_id}), 201
 
 
+@app.route('/snippets/<snippet_id>', methods=['GET'])
+def get_snippet(snippet_id):
+    if snippet_id not in snippets:
+        return jsonify({'error': 'Snippet not found'}), 404
+    return jsonify({'text': snippets[snippet_id]['text']}), 200
+
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,10 +1,26 @@
-from flask import Flask
+from flask import Flask, request, jsonify
+import uuid
 
 app = Flask(__name__)
+
+# In-memory storage for snippets
+snippets = {}  
 
 @app.route('/')
 def hello_world():
     return "Hello, World!"
+
+
+@app.route('/snippets', methods=['POST'])
+def create_snippet():
+    data = request.get_json()
+    if not data or 'text' not in data or not isinstance(data['text'], str):
+        return jsonify({'error': 'Invalid request data'}), 400
+    snippet_id = str(uuid.uuid4())[:6]
+    snippets[snippet_id] = {'text': data['text']}
+    
+    return jsonify({'id': snippet_id}), 201
+
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -24,3 +24,20 @@ def test_create_snippet():
         data = {"text": 123}
         response = client.post("/snippets", json=data)
         assert response.status_code == 400
+
+
+def test_get_snippet():
+    with app.test_client() as client:
+        # Create a snippet first
+        data = {'text': 'Test snippet'}
+        response = client.post('/snippets', json=data)
+        snippet_id = response.json['id']
+
+        # Test with a valid ID
+        response = client.get(f'/snippets/{snippet_id}')
+        assert response.status_code == 200
+        assert response.json['text'] == 'Test snippet'
+
+        # Test with an invalid ID
+        response = client.get('/snippets/invalid_id')
+        assert response.status_code == 404

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -1,7 +1,26 @@
 from app import app
 
+
 def test_hello_world():
     with app.test_client() as client:
-        response = client.get('/')
+        response = client.get("/")
         assert response.status_code == 200
         assert b"Hello, World!" in response.data
+
+
+def test_create_snippet():
+    with app.test_client() as client:
+        # Test with valid data
+        data = {"text": "This is a test snippet."}
+        response = client.post("/snippets", json=data)
+        assert response.status_code == 201
+        assert "id" in response.json
+
+        # Test with missing data
+        response = client.post("/snippets", json={})
+        assert response.status_code == 400
+
+        # Test with invalid data (e.g., non-string text)
+        data = {"text": 123}
+        response = client.post("/snippets", json=data)
+        assert response.status_code == 400


### PR DESCRIPTION
This pull request introduces two API endpoints for managing text snippets:

*   `/snippets` (POST): Creates a new snippet and returns its unique ID.
*   `/snippets/{id}` (GET): Retrieves a snippet by its ID.

Both endpoints include validation and error handling to ensure data integrity. The snippets are temporarily stored in memory.

Closes #2
Closes #3